### PR TITLE
Implement QuickSort for rust

### DIFF
--- a/programme/quick-sort/README.md
+++ b/programme/quick-sort/README.md
@@ -8,6 +8,7 @@ contributors:
   - KacperTKI
   - sandeepB3
   - udaybadhe
+  - Pablito2020
 ---
 
 ## Quick Sort

--- a/programme/quick-sort/quick-sort.rs
+++ b/programme/quick-sort/quick-sort.rs
@@ -1,3 +1,30 @@
+fn main() {
+    println!("Testing default test");
+    let x = &mut [5, 4, 1, 6, 2];
+    quicksort(x);
+    assert_eq!(&mut [1, 2, 4, 5, 6], x);
+    println!("Passed!");
+
+    println!("Testing empty test");
+    let mut x: Vec<i32> = vec![];
+    quicksort(&mut x);
+    let empty: Vec<i32> = vec![];
+    assert_eq!(empty , x);
+    println!("Passed!");
+
+    println!("Testing char test");
+    let x = &mut['p', 'c', 'a', 'b'];
+    quicksort(x);
+    assert_eq!(&mut['a', 'b', 'c', 'p'] , x);
+    println!("Passed!");
+
+    println!("Testing str test");
+    let x = &mut["pablo", "fraile", "alonso"];
+    quicksort(x);
+    assert_eq!(&mut["alonso", "fraile", "pablo"] , x);
+    println!("Passed!");
+}
+
 fn quicksort<T>(array: &mut [T]) where T: PartialEq + Eq + PartialOrd + Clone { 
     let len = array.len();
     if len <= 1 {
@@ -25,41 +52,4 @@ fn partition<T>(array: &mut[T], pivot_value: &T) -> usize where T: PartialEq + E
         }
     }
     smaller_number_index
-}
-
-/// Tests 
-#[cfg(test)]
-mod test {
-    use crate::quicksort;
-
-    #[test]
-    fn codinasion_test() {
-        let x = &mut [5, 4, 1, 6, 2];
-        quicksort(x);
-        assert_eq!(&mut [1, 2, 4, 5, 6], x);
-    }
-
-    #[test]
-    fn empty_test() {
-        let mut x: Vec<i32> = vec![];
-        quicksort(&mut x);
-        let empty: Vec<i32> = vec![];
-        assert_eq!(empty , x);
-    }
-
-    #[test]
-    fn chars_test() {
-        let x = &mut['p', 'c', 'a', 'b'];
-        quicksort(x);
-        assert_eq!(&mut['a', 'b', 'c', 'p'] , x);
-    }
-
-
-    #[test]
-    fn str_test() {
-        let x = &mut["pablo", "fraile", "alonso"];
-        quicksort(x);
-        assert_eq!(&mut["alonso", "fraile", "pablo"] , x);
-    }
-
 }

--- a/programme/quick-sort/quick-sort.rs
+++ b/programme/quick-sort/quick-sort.rs
@@ -1,28 +1,20 @@
 fn main() {
-    println!("Testing default test");
     let x = &mut [5, 4, 1, 6, 2];
     quicksort(x);
     assert_eq!(&mut [1, 2, 4, 5, 6], x);
-    println!("Passed!");
 
-    println!("Testing empty test");
     let mut x: Vec<i32> = vec![];
     quicksort(&mut x);
     let empty: Vec<i32> = vec![];
     assert_eq!(empty , x);
-    println!("Passed!");
 
-    println!("Testing char test");
     let x = &mut['p', 'c', 'a', 'b'];
     quicksort(x);
     assert_eq!(&mut['a', 'b', 'c', 'p'] , x);
-    println!("Passed!");
 
-    println!("Testing str test");
     let x = &mut["pablo", "fraile", "alonso"];
     quicksort(x);
     assert_eq!(&mut["alonso", "fraile", "pablo"] , x);
-    println!("Passed!");
 }
 
 fn quicksort<T>(array: &mut [T]) where T: PartialEq + Eq + PartialOrd + Clone { 

--- a/programme/quick-sort/quick-sort.rs
+++ b/programme/quick-sort/quick-sort.rs
@@ -1,0 +1,65 @@
+fn quicksort<T>(array: &mut [T]) where T: PartialEq + Eq + PartialOrd + Clone { 
+    let len = array.len();
+    if len <= 1 {
+        return;
+    }
+    let initial_pivot_position = choose_pivot_position(0, len);
+    let pivot_value = array[initial_pivot_position].clone();
+    array.swap(initial_pivot_position, len - 1);
+    let final_pivot_position = partition(&mut array[.. len - 1], &pivot_value);
+    array.swap(final_pivot_position, len - 1);
+    quicksort(&mut array[..final_pivot_position]);
+    quicksort(&mut array[final_pivot_position + 1..]);
+}
+
+fn choose_pivot_position(initial: usize, end: usize) -> usize {
+    initial + (end - initial) / 2
+}
+
+fn partition<T>(array: &mut[T], pivot_value: &T) -> usize where T: PartialEq + Eq + PartialOrd {
+    let mut smaller_number_index = 0;
+    for i in 0..array.len() { 
+        if pivot_value > &array[i] {
+            array.swap(i, smaller_number_index);
+            smaller_number_index += 1;
+        }
+    }
+    smaller_number_index
+}
+
+/// Tests 
+#[cfg(test)]
+mod test {
+    use crate::quicksort;
+
+    #[test]
+    fn codinasion_test() {
+        let x = &mut [5, 4, 1, 6, 2];
+        quicksort(x);
+        assert_eq!(&mut [1, 2, 4, 5, 6], x);
+    }
+
+    #[test]
+    fn empty_test() {
+        let mut x: Vec<i32> = vec![];
+        quicksort(&mut x);
+        let empty: Vec<i32> = vec![];
+        assert_eq!(empty , x);
+    }
+
+    #[test]
+    fn chars_test() {
+        let x = &mut['p', 'c', 'a', 'b'];
+        quicksort(x);
+        assert_eq!(&mut['a', 'b', 'c', 'p'] , x);
+    }
+
+
+    #[test]
+    fn str_test() {
+        let x = &mut["pablo", "fraile", "alonso"];
+        quicksort(x);
+        assert_eq!(&mut["alonso", "fraile", "pablo"] , x);
+    }
+
+}


### PR DESCRIPTION
### Why:

Closes #135 

### What's being changed:
Added an implementation of quicksort that uses generics and is easy to understand and read.

### Check off the following:

- [x] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [x] For content changes, I have completed the [self-review checklist](https://github.com/codinasion/codinasion/blob/master/contributing/self-review.md).
